### PR TITLE
Fix pip installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,5 +41,6 @@ setuptools.setup(
             'Operating System :: OS Independent',
         ],
         install_requires=requirements,
-        python_requires='>=3.5'
+        python_requires='>=3.5',
+        package_data={ 'gibberify': ['config/config.json'] }
         )


### PR DESCRIPTION
This should work to fix installing the default config but it complains with this error:
```
Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/matthijs/.local/lib/python3.7/site-packages/gibberify-0.5.0-py3.7.egg/gibberify/__main__.py", line 9, in <module>
    main()
  File "/home/matthijs/.local/lib/python3.7/site-packages/gibberify-0.5.0-py3.7.egg/gibberify/cli.py", line 114, in main
    run(args)
  File "/home/matthijs/.local/lib/python3.7/site-packages/gibberify-0.5.0-py3.7.egg/gibberify/cli.py", line 78, in run
    conf = Config.from_json()
  File "/home/matthijs/.local/lib/python3.7/site-packages/gibberify-0.5.0-py3.7.egg/gibberify/config/config.py", line 64, in from_json
    return cls(json.load(f))
  File "/usr/lib/python3.7/json/__init__.py", line 296, in load
    parse_constant=parse_constant, object_pairs_hook=object_pairs_hook, **kw)
  File "/usr/lib/python3.7/json/__init__.py", line 348, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.7/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.7/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```